### PR TITLE
docs: use pnpm run plugins install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Use the ``/admin`` interface, search for ``ep_what_have_i_missed`` and click Ins
 
 Option 2.
 ```
-npm install ep_what_have_i_missed
+pnpm run plugins install ep_what_have_i_missed
 ```
 
 Option 3.


### PR DESCRIPTION
## Summary
Etherpad uses pnpm internally. The canonical install command per [etherpad-lite/doc/plugins.md](https://github.com/ether/etherpad-lite/blob/develop/doc/plugins.md) is `pnpm run plugins install ep_<name>`, not `npm install`. Update README to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)