### PR TITLE
refactor: adopt template helper for 2 simple eejsBlock_* hook(s)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const {template} = require('ep_plugin_helpers');
+
 /**
  * Copyright 2020 John McLear <john@mclear.co.uk>
  *
@@ -32,13 +34,9 @@ exports.eejsBlock_mySettings = (hook, context, callback) => {
   callback();
 };
 
-exports.eejsBlock_customStyles = (hookName, args, cb) => {
-  args.content += eejs.require('./templates/styles.html', {}, module);
-  cb();
-};
+exports.eejsBlock_customStyles =
+    template('./templates/styles.html');
 
 
-exports.eejsBlock_body = (hookName, args, cb) => {
-  args.content += eejs.require('./templates/diff.ejs', {}, module);
-  return cb();
-};
+exports.eejsBlock_body =
+    template('./templates/diff.ejs');

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/ether/ep_what_have_i_missed.git"
+  },
+  "dependencies": {
+    "ep_plugin_helpers": "^0.5.0"
   }
 }


### PR DESCRIPTION
## Summary

Adopts `template()` from `ep_plugin_helpers` for 2 `eejsBlock_*` hook(s) of shape:

```js
exports.eejsBlock_X = (hookName, args, cb) => {
  args.content += eejs.require('plugin/template.ejs'[, {}[, module]]);
  cb();
};
```

Replaced with `exports.eejsBlock_X = template('plugin/template.ejs');`. Same runtime behavior.

Part of Phase 4 of the modernization campaign. Wave 1: ether/ep_themes#103 + 6 small plugins. Wave 2 picks up hooks with explicit empty-vars / module argument that wave 1's stricter regex skipped.