### PR TITLE
fix: use absolute template paths for ep_plugin_helpers template()

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,8 +35,8 @@ exports.eejsBlock_mySettings = (hook, context, callback) => {
 };
 
 exports.eejsBlock_customStyles =
-    template('./templates/styles.html');
+    template('ep_what_have_i_missed/templates/styles.html');
 
 
 exports.eejsBlock_body =
-    template('./templates/diff.ejs');
+    template('ep_what_have_i_missed/templates/diff.ejs');


### PR DESCRIPTION
## Summary

Fixes runtime resolution failure for templates introduced by the earlier Phase 4 `template` helper adoption.

`ep_plugin_helpers/eejs-blocks.js` calls `eejs.require(templatePath, vars, module)` with **its own** module reference. `eejs.require` uses that module's `__dirname` as the resolve basedir, so a relative path like `./templates/styles.html` resolves against `ep_plugin_helpers/` (not this plugin's directory) and fails.

This PR rewrites `template('./templates/X')` to `template('ep_what_have_i_missed/templates/X')`. With an absolute path of the shape `<plugin>/<file>`, etherpad's `pluginInstallPath` resolution kicks in and locates the file correctly.

This should land before the next end-user upgrades to a build that ships these plugins, otherwise affected blocks will throw at render time.